### PR TITLE
Install esp32:esp32 platform correctly in CI workflow

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -18,9 +18,10 @@ jobs:
       - name: Compile sketch
         uses: arduino/compile-sketches@v1
         with:
+          fqbn: esp32:esp32:esp32wrover
           platforms: |
-            - source-url: https://github.com/espressif/arduino-esp32.git
-              name: espressif:ESP32 Wrover Module
+            - source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+              name: esp32:esp32
           verbose: true
           enable-deltas-report: true
           enable-warnings-report: true


### PR DESCRIPTION
This change causes the latest release of the ESP32 boards platform to be installed via Boards Manager and the sketches to be compiled for its "ESP32 Wrover Module" board (https://github.com/espressif/arduino-esp32/blob/1.0.6/boards.txt#L157).

It was not clear to me whether you truly intended to use the unstable development version of the platform from the tip of the default branch of https://github.com/espressif/arduino-esp32.git. If so, you will still want to install the release version, as was done here, in order to install the toolchain (which cloning https://github.com/espressif/arduino-esp32.git doesn't provide), but then you'll want to add an additional element to the `platforms` input list which installs the platform via Git clone, overwriting the release platform that was installed via Boards Manager:
```yaml
platforms:
  - source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
    name: esp32:esp32
  - source-url: https://github.com/espressif/arduino-esp32.git
    name: esp32:esp32
```

This pull request does not provide you with a working CI workflow. The run is still failing due to missing library dependencies (and it looks like maybe at least one sketch is incompatible with ESP32), but it gets you one step closer to that goal.